### PR TITLE
oh-my-zsh compatibility

### DIFF
--- a/zsh-abbr-path.plugin.zsh
+++ b/zsh-abbr-path.plugin.zsh
@@ -1,0 +1,1 @@
+source ${0:A:h}/.abbr_pwd


### PR DESCRIPTION
omz wants an entry file `${plugin_name}.plugin.zsh`. Now I can just clone this into my plugins.